### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/common-test.yaml
+++ b/.github/workflows/common-test.yaml
@@ -8,8 +8,8 @@ jobs:
     name: common-test-build
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: 23
       - run: npm i -g @nestjs/cli nx

--- a/.github/workflows/realio-mainnet.yml
+++ b/.github/workflows/realio-mainnet.yml
@@ -18,26 +18,26 @@ jobs:
     environment: realio-mainnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ secrets.IMAGE_REGISTRY_URL }}
           username: ${{ secrets.IMAGE_REGISTRY_USER }}
           password: ${{ secrets.ACCESS_TOKEN }}
       - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ github.workflow }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ github.workflow }}-buildx-${{ github.sha }}
             ${{ github.workflow }}
-      - uses: 1password/install-cli-action@v2
+      - uses: 1password/install-cli-action@9a0c9dd934086b7ab1d90115d455bda1c53c2bdb # v2
       - name: Load REALIO_PUBLIC vars
         env:
           OP_VAULT: gitops-pubrepo-prod
@@ -55,7 +55,7 @@ jobs:
             echo "$line set" | tr -d '"'
           done
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           push: true
           tags: ${{ secrets.IMAGE_REGISTRY_URL }}/${{ secrets.IMAGE_REPO }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
@@ -82,7 +82,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         token: ${{ secrets.GITOPS_PAT }}
         repository: ${{ secrets.GITOPS_REPO }}

--- a/.github/workflows/realio-testnet.yml
+++ b/.github/workflows/realio-testnet.yml
@@ -18,26 +18,26 @@ jobs:
     environment: realio-testnet
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ secrets.IMAGE_REGISTRY_URL }}
           username: ${{ secrets.IMAGE_REGISTRY_USER }}
           password: ${{ secrets.ACCESS_TOKEN }}
       - name: GitHub Actions Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ github.workflow }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ github.workflow }}-buildx-${{ github.sha }}
             ${{ github.workflow }}
-      - uses: 1password/install-cli-action@v2
+      - uses: 1password/install-cli-action@9a0c9dd934086b7ab1d90115d455bda1c53c2bdb # v2
       - name: Load REALIO_PUBLIC vars
         env:
           OP_VAULT: gitops-pubrepo-stage
@@ -55,7 +55,7 @@ jobs:
             echo "$line set" | tr -d '"'
           done
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           push: true
           tags: ${{ secrets.IMAGE_REGISTRY_URL }}/${{ secrets.IMAGE_REPO }}/${{ secrets.IMAGE_NAME }}:${{ github.sha }}-${{ github.run_number }}
@@ -82,7 +82,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Checkout gitops repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         token: ${{ secrets.GITOPS_PAT }}
         repository: ${{ secrets.GITOPS_REPO }}


### PR DESCRIPTION
## Summary
- Pins GitHub Actions in workflow files to immutable commit SHAs (security best practice — prevents tag-rewrite supply-chain attacks).
- Adds `.github/dependabot.yml` so Dependabot keeps the pinned SHAs up to date going forward.

## Test plan
- [ ] Workflow runs trigger and pass on this branch.
- [ ] Dependabot detects the new config and opens its first update PR within 24h.