### PR TITLE
chore: gate npm installs by 3-day minimum release age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+min-release-age=3
+audit-level=critical
+engine-strict=true
+registry=https://registry.npmjs.org/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ ARG PRICE_API_URL
 WORKDIR /app
 
 # Installing dependencies
-COPY package*.json ./
+COPY package*.json .npmrc ./
+RUN npm i -g npm@latest
 RUN --mount=type=cache,target=/root/.npm npm ci
 RUN npx browserslist@latest --update-db
 

--- a/Dockerfile-bitbucket
+++ b/Dockerfile-bitbucket
@@ -9,7 +9,7 @@ RUN apk add --no-cache git
 WORKDIR /app
 
 # Installing dependencies
-COPY package*.json ./
+COPY package*.json .npmrc ./
 RUN mkdir node_modules
 RUN npm ci
 RUN npx browserslist@latest --update-db


### PR DESCRIPTION
Mirrors #57 onto the `chains/realio-testnet` branch.

**Changes**
- Add `.npmrc` with supply-chain hardening: `min-release-age=3`, `audit-level=critical`, `engine-strict=true`, `registry=https://registry.npmjs.org/`.
- `Dockerfile` (node:23): copy `.npmrc` before `npm ci` and `RUN npm i -g npm@latest` so npm ≥ 11.10.0 honors `min-release-age`.
- `Dockerfile-bitbucket` (node:14, legacy): copy `.npmrc` before `npm ci` (npm too old for `min-release-age`; other keys apply).
